### PR TITLE
tag property for translate component

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -27,6 +27,10 @@ export default {
   },
 
   props: {
+    tag: {
+      type: String,
+      default: 'span',
+    },
     // Always use v-bind for dynamically binding the `translateN` prop to data on the parent,
     // i.e.: `:translateN`.
     translateN: {
@@ -63,7 +67,7 @@ export default {
   render: function (createElement) {
     // The text must be wraped inside a root HTML element, so we use a <span>.
     // https://github.com/vuejs/vue/blob/a4fcdb/src/compiler/parser/index.js#L209
-    return createElement('span', [this.translation])
+    return createElement(this.tag, [this.translation])
   },
 
 }

--- a/test/specs/component.spec.js
+++ b/test/specs/component.spec.js
@@ -46,6 +46,12 @@ describe('translate component tests', () => {
     expect(vm.$el.innerHTML.trim()).to.equal('<span>En cours</span>')
   })
 
+  it('renders translation in custom html tag', () => {
+    Vue.config.language = 'fr_FR'
+    let vm = new Vue({template: '<div><translate tag="h1">Pending</translate></div>'}).$mount()
+    expect(vm.$el.innerHTML.trim()).to.equal('<h1>En cours</h1>')
+  })
+
   it('translates known strings according to a given translation context', () => {
     Vue.config.language = 'en_US'
     let vm = new Vue({template: '<div><translate translate-context="Verb">Answer</translate></div>'}).$mount()


### PR DESCRIPTION
Allows to render translation in custom HTML tag, i.e.:
```<translate tag="h1">Translated headline</translate>```
renders:
```<h1>Translated headline</h1>```