### PR TITLE
Try splitting language ID with a "-"

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -21,12 +21,16 @@ export default {
     }
 
     // `easygettext`'s `gettext-compile` generates a JSON version of a .po file based on its `Language` field.
-    // But in this field, `ll_CC` combinations denoting a language’s main dialect are abbreviated as `ll`,
+    // But in this field, `ll_CC` or `ll-CC` combinations denoting a language’s main dialect are abbreviated as `ll`,
     // for example `de` is equivalent to `de_DE` (German as spoken in Germany).
     // See the `Language` section in https://www.gnu.org/software/gettext/manual/html_node/Header-Entry.html
-    // So try `ll_CC` first, or the `ll` abbreviation which can be three-letter sometimes:
+    // So try `ll_CC` or `ll-CC` first, or the `ll` abbreviation which can be three-letter sometimes:
     // https://www.gnu.org/software/gettext/manual/html_node/Language-Codes.html#Language-Codes
-    let translations = _Vue.$translations[language] || _Vue.$translations[language.split('_')[0]]
+    let translations = (
+       _Vue.$translations[language] || 
+       _Vue.$translations[language.split('_')[0]] || 
+       _Vue.$translations[language.split('-')[0]]
+     )
 
     if (!translations) {
       if (!_Vue.config.getTextPluginSilent) {


### PR DESCRIPTION
Browsers and other environments often use "-" to separate the language and country code. Just open the console up now and check `navigator.language`. It would be nice to make this use case easy instead of having to replace the underscore with a dash before setting the language.