### PR TITLE
Warn the usage of mustache syntax and give suggestion

### DIFF
--- a/src/interpolate.js
+++ b/src/interpolate.js
@@ -1,3 +1,5 @@
+import { _Vue } from './localVue'
+
 /* Interpolation RegExp.
  *
  * Because interpolation inside attributes are deprecated in Vue 2 we have to
@@ -15,6 +17,8 @@
  */
 const INTERPOLATION_RE = /%\{((?:.|\n)+?)\}/g
 
+const MUSTACHE_SYNTAX_RE = /\{\{((?:.|\n)+?)\}\}/g
+
 /**
  * Evaluate a piece of template string containing %{ } placeholders.
  * E.g.: 'Hi %{ user.name }' => 'Hi Bob'
@@ -28,6 +32,10 @@ const INTERPOLATION_RE = /%\{((?:.|\n)+?)\}/g
  * @return {String} The interpolated string
  */
 let interpolate = function (msgid, context = {}) {
+
+  if (!_Vue.config.getTextPluginSilent && MUSTACHE_SYNTAX_RE.test(msgid)) {
+    console.warn(`Mustache syntax is detected. Please use \`%{}\` instead of \`{{}}\` in: ${msgid}`)
+  }
 
   let result = msgid.replace(INTERPOLATION_RE, (match, token) => {
 

--- a/test/specs/interpolate.spec.js
+++ b/test/specs/interpolate.spec.js
@@ -1,7 +1,19 @@
+import Vue from 'vue'
+
+import GetTextPlugin from '../../src/'
 import interpolate from '../../src/interpolate'
+import translations from './json/translate.json'
 
 
 describe('Interpolate tests', () => {
+
+  beforeEach(function () {
+    GetTextPlugin.installed = false
+    Vue.use(GetTextPlugin, {
+      translations: translations,
+      silent: true,
+    })
+  })
 
   it('without placeholders', () => {
     let msgid = 'Foo bar baz'
@@ -92,6 +104,20 @@ describe('Interpolate tests', () => {
     interpolate(msgid, context)
     expect(console.warn).calledOnce
     expect(console.warn).calledWith('Cannot evaluate expression: "alert("foobar")".')
+    console.warn.restore()
+  })
+
+  it('should warn of the usage of mustache syntax', () => {
+    let msgid = 'Foo {{ foo }} baz'
+    let context = {
+      foo: 'bar',
+    }
+    console.warn = sinon.spy(console, 'warn')
+    interpolate(msgid, context)
+    expect(console.warn).notCalled
+    Vue.config.getTextPluginSilent = false
+    interpolate(msgid, context)
+    expect(console.warn).calledOnce
     console.warn.restore()
   })
 


### PR DESCRIPTION
Sometimes I just forget to convert `{{ }}` to `%{ }` and I thought it'd be nice to have a bit of warning.