### PR TITLE
Pluralization is wrong for 0 in English when there are no English translations.  

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -32,7 +32,7 @@ export default {
       if (!_Vue.config.getTextPluginSilent) {
         console.warn(`No translations found for ${language}`)
       }
-      return defaultPlural && n > 1 ? defaultPlural : msgid  // Returns the untranslated string, singular or plural.
+      return defaultPlural && plurals.getTranslationIndex(language, n) > 0 ? defaultPlural : msgid  // Returns the untranslated string, singular or plural.
     }
 
     let translated = translations[msgid]
@@ -52,7 +52,7 @@ export default {
       if (!_Vue.config.getTextPluginSilent) {
         console.warn(`Untranslated ${language} key found:\n${msgid}`)
       }
-      return defaultPlural && n > 1 ? defaultPlural : msgid  // Returns the untranslated string, singular or plural.
+      return defaultPlural && plurals.getTranslationIndex(language, n) > 0 ? defaultPlural : msgid  // Returns the untranslated string, singular or plural.
     }
 
     if (context) {

--- a/test/specs/translate.spec.js
+++ b/test/specs/translate.spec.js
@@ -61,6 +61,13 @@ describe('Translate tests', () => {
     translated = translate.getTranslation('Object', null, 'Context', null, 'fr_FR')
     expect(translated).to.equal('Objet avec contexte')
 
+    // Ensure that pluralization is right in English when there are no English translations.
+    translated = translate.getTranslation('Untranslated %{ n } item', 0, null, 'Untranslated %{ n } items', 'en_US')
+    expect(translated).to.equal('Untranslated %{ n } items')
+    translated = translate.getTranslation('Untranslated %{ n } item', 1, null, 'Untranslated %{ n } items', 'en_US')
+    expect(translated).to.equal('Untranslated %{ n } item')
+    translated = translate.getTranslation('Untranslated %{ n } item', 2, null, 'Untranslated %{ n } items', 'en_US')
+    expect(translated).to.equal('Untranslated %{ n } items')
   })
 
   it('tests the gettext() method', () => {


### PR DESCRIPTION
Before you have translations (or in the case of developing in English where you never need translations for English) pluralization does not work correctly for all languages.  Currently getTranslations just says if the number is greater than 1 return the plural form otherwise return the singular.  However, in English 0 requires the plural form.  By looking up the language pluralization rules by language in this case you get a more accurate result.
