### PR TITLE
Update Readme.md to make this case clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ The directive has the same set of capabilities as the component, **except for tr
 ```html
 <p
   v-translate='{count: carNumbers}'
-  :translate-n="count"
+  :translate-n="carNumbers"
   translate-plural="<strong>%{ count }</strong> cars"
   translate-comment="My comment for translators"
   >


### PR DESCRIPTION
`:translate-n="count"` would only work if `v-translate='{count: count}'`.
See: https://jsfiddle.net/escapedcat/rwbz962e/

Let me know if this is wrong. Thanks.