### PR TITLE
Safely evaluate expressions

### DIFF
--- a/src/interpolate.js
+++ b/src/interpolate.js
@@ -15,6 +15,8 @@ import { _Vue } from './localVue'
  *   \}                 => Ending delimiter: `}`
  * /g                   => Global: don't return after first match
  */
+const EVALUATION_RE = /[[\].]{1,2}/g
+
 const INTERPOLATION_RE = /%\{((?:.|\n)+?)\}/g
 
 const MUSTACHE_SYNTAX_RE = /\{\{((?:.|\n)+?)\}\}/g
@@ -42,9 +44,17 @@ let interpolate = function (msgid, context = {}) {
     const expression = token.trim()
     let evaluated
 
+    function getProps (obj, expression) {
+      var arr = expression.split(EVALUATION_RE).filter(x => x)
+      while (arr.length) {
+        obj = obj[arr.shift()]
+      }
+      return obj
+    }
+
     function evalInContext (expression) {
       try {
-        evaluated = eval('this.' + expression)  // eslint-disable-line no-eval
+        evaluated = getProps(this, expression)
       } catch (e) {
         // Ignore errors, because this function may be called recursively later.
       }

--- a/src/interpolate.js
+++ b/src/interpolate.js
@@ -45,7 +45,7 @@ let interpolate = function (msgid, context = {}) {
     let evaluated
 
     function getProps (obj, expression) {
-      var arr = expression.split(EVALUATION_RE).filter(x => x)
+      const arr = expression.split(EVALUATION_RE).filter(x => x)
       while (arr.length) {
         obj = obj[arr.shift()]
       }


### PR DESCRIPTION
Hello!

When I was looking at the code a while back, I noticed that there was an `eval` call in the `src/interpolate.js` file.

MDN does [not recommend eval](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval) so I thought about taking their `getDescendantProp()` function and tweaked it a bit. Should be a little bit more safe now and Rollup/ESLint shouldn't complain anymore.

All 73 tests pass, but please let me know if you wanted me to add some more.

Thank you!