### PR TITLE
Trim whitespaces in `msgid`

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -69,7 +69,7 @@ export default {
 
     // Get the raw HTML and store it in the element's dataset (as advised in Vue's official guide).
     // Note: not trimming the content here as it should be picked up as-is by the extractor.
-    let msgid = el.innerHTML
+    let msgid = el.innerHTML.trim()
     el.dataset.msgid = msgid
 
     // Store the current language in the element's dataset.

--- a/test/specs/directive.spec.js
+++ b/test/specs/directive.spec.js
@@ -47,9 +47,27 @@ describe('translate directive tests', () => {
     expect(vm.$el.innerHTML).to.equal('En cours')
   })
 
+  it('translates known strings when surrounded by whitespace', () => {
+    Vue.config.language = 'fr_FR'
+    let vm = new Vue({template: '<div v-translate> Pending\t</div>'}).$mount()
+    expect(vm.$el.innerHTML).to.equal('En cours')
+  })
+
   it('translates multiline strings as-is, preserving the original content', () => {
     Vue.config.language = 'fr_FR'
     let vm = new Vue({template: '<p v-translate>A\n\n\nlot\n\n\nof\n\nlines</p>'}).$mount()
+    expect(vm.$el.innerHTML).to.equal('Plein\n\n\nde\n\nlignes')
+  })
+
+  it('translates multiline strings even when begins with newline', () => {
+    Vue.config.language = 'fr_FR'
+    let vm = new Vue({template: '<p v-translate>\nA\n\n\nlot\n\n\nof\n\nlines\n</p>'}).$mount()
+    expect(vm.$el.innerHTML).to.equal('Plein\n\n\nde\n\nlignes')
+  })
+
+  it('translates multiline strings even when indented', () => {
+    Vue.config.language = 'fr_FR'
+    let vm = new Vue({template: '<p v-translate>\n  A\n  lot\n  of\n  lines\n</p>'}).$mount()
     expect(vm.$el.innerHTML).to.equal('Plein\n\n\nde\n\nlignes')
   })
 


### PR DESCRIPTION
This sometimes prevent translations in cases like:

    <div v-translate>
        Test
    </div>

And while `easygettext` omit whitespaces in this situation it causes
problems.