### PR TITLE
Improve makefile on multi-user system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@
 SHELL = /bin/bash
 NODE_BINDIR = ./node_modules/.bin
 export PATH := $(NODE_BINDIR):$(PATH)
+LOGNAME ?= $(shell logname)
+
+# adding the name of the user's login name to the template file, so that
+# on a multi-user system several users can run this without interference
+TEMPLATE_POT ?= /tmp/template-$(LOGNAME).pot
 
 # Where to find input files (it can be multiple paths).
 INPUT_FILES = ./dev
@@ -21,18 +26,18 @@ GETTEXT_SOURCES ?= $(shell find $(INPUT_FILES) -name '*.jade' -o -name '*.html' 
 .PHONY: clean makemessages translations all
 
 all:
-	@echo choose a traget form: clean makemessages translations
+	@echo choose a target from: clean makemessages translations
 
 clean:
-	rm -f /tmp/template.pot $(OUTPUT_DIR)/translations.json
+	rm -f $(TEMPLATE_POT) $(OUTPUT_DIR)/translations.json
 
-makemessages: /tmp/template.pot
+makemessages: $(TEMPLATE_POT)
 
 translations: ./$(OUTPUT_DIR)/translations.json
 
 # Create a main .pot template, then generate .po files for each available language.
 # Thanx to Systematic: https://github.com/Polyconseil/systematic/blob/866d5a/mk/main.mk#L167-L183
-/tmp/template.pot: $(GETTEXT_SOURCES)
+$(TEMPLATE_POT): $(GETTEXT_SOURCES)
 # `dir` is a Makefile built-in expansion function which extracts the directory-part of `$@`.
 # `$@` is a Makefile automatic variable: the file name of the target of the rule.
 # => `mkdir -p /tmp/`


### PR DESCRIPTION
* Add ability to run the translations Makefile with several users
on a multi-user system. For this add -$(LOGNAME) to the template.pot
file. This leave the behaviour of this file as is, it still can be
inspected. And it allows for parallel use of several users.
* correct typo


**resolve** #86