### PR TITLE
Fix getTranslation method for plurals with context

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -79,14 +79,14 @@ export default {
       return untranslated
     }
 
-    if (typeof translated === 'string') {
-      translated = [translated]
-    }
-
     // Avoid a crash when a msgid exists with and without a context, see #32.
     if (!(translated instanceof Array) && translated.hasOwnProperty('')) {
       // As things currently stand, the void key means a void context for easygettext.
-      translated = [translated['']]
+      translated = translated['']
+    }
+
+    if (typeof translated === 'string') {
+      translated = [translated]
     }
 
     let translationIndex = plurals.getTranslationIndex(language, n)

--- a/test/specs/json/translate.json
+++ b/test/specs/json/translate.json
@@ -23,6 +23,16 @@
                 "%{ carCount } cars (verb)"
             ]
         },
+        "%{ carCount } car (multiple contexts)": {
+            "": [
+                "1 car",
+                "%{ carCount } cars"
+            ],
+            "Context": [
+                "1 car with context",
+                "%{ carCount } cars with context"
+            ]
+        },
         "Object": {
             "": "Object",
             "Context": "Object with context"
@@ -50,6 +60,16 @@
             "Verb": [
                 "%{ carCount } véhicule (verbe)",
                 "%{ carCount } véhicules (verbe)"
+            ]
+        },
+        "%{ carCount } car (multiple contexts)": {
+            "": [
+                "1 véhicule",
+                "%{ carCount } véhicules"
+            ],
+            "Context": [
+                "1 véhicule avec contexte",
+                "%{ carCount } véhicules avec contexte"
             ]
         },
         "Object": {

--- a/test/specs/translate.spec.js
+++ b/test/specs/translate.spec.js
@@ -70,6 +70,16 @@ describe('Translate tests', () => {
     translated = translate.getTranslation('Untranslated %{ n } item', 2, null, 'Untranslated %{ n } items', 'en_US')
     expect(translated).to.equal('Untranslated %{ n } items')
 
+    // Test plural message with multiple contexts (default context and 'Context'')
+    translated = translate.getTranslation('%{ carCount } car (multiple contexts)', 1, null, null, 'en_US')
+    expect(translated).to.equal('1 car')
+    translated = translate.getTranslation('%{ carCount } car (multiple contexts)', 2, null, null, 'en_US')
+    expect(translated).to.equal('%{ carCount } cars')
+    translated = translate.getTranslation('%{ carCount } car (multiple contexts)', 1, 'Context', null, 'en_US')
+    expect(translated).to.equal('1 car with context')
+    translated = translate.getTranslation('%{ carCount } car (multiple contexts)', 2, 'Context', null, 'en_US')
+    expect(translated).to.equal('%{ carCount } cars with context')
+
   })
 
   it('tests the gettext() method', () => {


### PR DESCRIPTION
In case of plural translations that have multiple contexts (one of them being the default context) `getTranslation()` returns the wrong result. Instead of the correct string it returns the whole array of plural translations. The cause of this is the this [part of the method](https://github.com/Polyconseil/vue-gettext/blob/a84961caa18397b62f7bec16ef97d572116cfad7/src/translate.js#L87-L90):

```js
if (!(translated instanceof Array) && translated.hasOwnProperty('')) {
      // As things currently stand, the void key means a void context for easygettext.
      translated = [translated['']]
}
```

This code assumes that the value of `translated['']` is a singular message (i.e. a string) and therefore wraps it in an array. This PR fixes this by removing the array and moving the existing normalization logic after this code.