### PR TITLE
Infinity should be treated as plural

### DIFF
--- a/src/plurals.js
+++ b/src/plurals.js
@@ -11,7 +11,7 @@ export default {
 
   getTranslationIndex: function (languageCode, n) {
 
-    n = parseInt(n)
+    n = Number(n)
     n = typeof n === 'number' && isNaN(n) ? 1 : n  // Fallback to singular.
 
     // Extract the ISO 639 language code. The ISO 639 standard defines

--- a/test/specs/plurals.spec.js
+++ b/test/specs/plurals.spec.js
@@ -11,6 +11,10 @@ describe('Translate plurals tests', () => {
     expect(plurals.getTranslationIndex('en', 2)).to.equal(1)
   })
 
+  it('plural form of Infinity in english is 1', function () {
+    expect(plurals.getTranslationIndex('en', Infinity)).to.equal(1)
+  })
+
   it('plural form of zero in english is 1', function () {
     expect(plurals.getTranslationIndex('en', 0)).to.equal(1)
   })


### PR DESCRIPTION
In plural.js, `parseInt()`[0] is used to check if the given input is a
number. However the radix argument for `parseInt()` is omitted which can
produce unexpected behaviors; this is discouraged by the MDN[1].

Anyways if we are using Infinity (for example with `$ngettext(singular, plural,
Infinity)`) then the expected translation should be plural instead of
singular.

[0] https://tc39.es/ecma262/#sec-parseint-string-radix
[1] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt