### PR TITLE
Decouple Vue from translate.js

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -18,6 +18,7 @@ module.exports = {
     format: 'umd',
     globals,
     name: 'VueGettext',
+    exports: 'named',
   },
   external: Object.keys(globals),
   plugins: [

--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,8 @@ let GetTextPlugin = function (Vue, options = {}) {
 
   Config(Vue, languageVm, options.silent, options.autoAddKeyAttributes, options.muteLanguages)
 
+  translate.initTranslations(options.translations, Vue.config)
+
   // Makes <translate> available as a global component.
   Vue.component('translate', Component)
 

--- a/src/index.js
+++ b/src/index.js
@@ -72,3 +72,4 @@ let GetTextPlugin = function (Vue, options = {}) {
 }
 
 export default GetTextPlugin
+export {translate}

--- a/src/translate.js
+++ b/src/translate.js
@@ -1,7 +1,14 @@
 import plurals from './plurals'
-import { _Vue } from './localVue'
 
 const SPACING_RE = /\s{2,}/g
+// Default configuration if only the translation is passed.
+let _config = {
+  language: '',
+  getTextPluginSilent: false,
+  getTextPluginMuteLanguages: [],
+  silent: false,
+}
+let _translations = {}
 
 export default {
 
@@ -16,13 +23,13 @@ export default {
    *
    * @return {String} The translated string
   */
-  getTranslation: function (msgid, n = 1, context = null, defaultPlural = null, language = _Vue.config.language) {
+  getTranslation: function (msgid, n = 1, context = null, defaultPlural = null, language = _config.language) {
 
     if (!msgid) {
       return ''  // Allow empty strings.
     }
 
-    let silent = _Vue.config.getTextPluginSilent || (_Vue.config.getTextPluginMuteLanguages.indexOf(language) !== -1)
+    let silent = _config.getTextPluginSilent || (_config.getTextPluginMuteLanguages.indexOf(language) !== -1)
 
     // Default untranslated string, singular or plural.
     let untranslated = defaultPlural && plurals.getTranslationIndex(language, n) > 0 ? defaultPlural : msgid
@@ -33,7 +40,7 @@ export default {
     // See the `Language` section in https://www.gnu.org/software/gettext/manual/html_node/Header-Entry.html
     // So try `ll_CC` first, or the `ll` abbreviation which can be three-letter sometimes:
     // https://www.gnu.org/software/gettext/manual/html_node/Language-Codes.html#Language-Codes
-    let translations = _Vue.$translations[language] || _Vue.$translations[language.split('_')[0]]
+    let translations = _translations[language] || _translations[language.split('_')[0]]
 
     if (!translations) {
       if (!silent) {
@@ -157,4 +164,20 @@ export default {
     return this.getTranslation(msgid, n, context, plural)
   },
 
+  /*
+   * Initialize local state for translations and configuration
+   * so that it works without Vue.
+   *
+   * @param {Object} translations - translations.json
+   * @param {Object} config - Vue.config
+   *
+  */
+  initTranslations: function (translations, config) {
+    if (translations && typeof translations === 'object') {
+      _translations = translations
+    }
+    if (config && typeof config === 'object') {
+      _config = config
+    }
+  },
 }

--- a/test/specs/translate.spec.js
+++ b/test/specs/translate.spec.js
@@ -179,3 +179,176 @@ describe('Translate tests', () => {
   })
 
 })
+
+describe('Translate tests without Vue', () => {
+  let config
+
+  beforeEach(function () {
+    config = {
+      language: 'en_US',
+      getTextPluginSilent: false,
+      getTextPluginMuteLanguages: [],
+      silent: false,
+    }
+    translate.initTranslations(translations, config)
+  })
+
+  let translated
+
+  it('tests the getTranslation() method', () => {
+
+    translated = translate.getTranslation('', 1, null, 'fr_FR')
+    expect(translated).to.equal('')
+
+    translated = translate.getTranslation('Unexisting language', null, null, null, 'be_FR')
+    expect(translated).to.equal('Unexisting language')
+
+    translated = translate.getTranslation('Untranslated key', null, null, null, 'fr_FR')
+    expect(translated).to.equal('Untranslated key')
+
+    translated = translate.getTranslation('Pending', 1, null, null, 'fr_FR')
+    expect(translated).to.equal('En cours')
+
+    translated = translate.getTranslation('%{ carCount } car', 2, null, null, 'fr_FR')
+    expect(translated).to.equal('%{ carCount } véhicules')
+
+    translated = translate.getTranslation('Answer', 1, 'Verb', null, 'fr_FR')
+    expect(translated).to.equal('Réponse (verbe)')
+
+    translated = translate.getTranslation('Answer', 1, 'Noun', null, 'fr_FR')
+    expect(translated).to.equal('Réponse (nom)')
+
+    translated = translate.getTranslation('Pending', 1, null, null, 'en_US')
+    expect(translated).to.equal('Pending')
+
+    // If no translation exists, display the default singular form (if n < 2).
+    translated = translate.getTranslation('Untranslated %{ n } item', 0, null, 'Untranslated %{ n } items', 'fr_FR')
+    expect(translated).to.equal('Untranslated %{ n } item')
+
+    // If no translation exists, display the default plural form (if n > 1).
+    translated = translate.getTranslation('Untranslated %{ n } item', 10, null, 'Untranslated %{ n } items', 'fr_FR')
+    expect(translated).to.equal('Untranslated %{ n } items')
+
+    // Test that it works when a msgid exists with and without a context, see #32.
+    translated = translate.getTranslation('Object', null, null, null, 'fr_FR')
+    expect(translated).to.equal('Objet')
+    translated = translate.getTranslation('Object', null, 'Context', null, 'fr_FR')
+    expect(translated).to.equal('Objet avec contexte')
+
+    // Ensure that pluralization is right in English when there are no English translations.
+    translated = translate.getTranslation('Untranslated %{ n } item', 0, null, 'Untranslated %{ n } items', 'en_US')
+    expect(translated).to.equal('Untranslated %{ n } items')
+    translated = translate.getTranslation('Untranslated %{ n } item', 1, null, 'Untranslated %{ n } items', 'en_US')
+    expect(translated).to.equal('Untranslated %{ n } item')
+    translated = translate.getTranslation('Untranslated %{ n } item', 2, null, 'Untranslated %{ n } items', 'en_US')
+    expect(translated).to.equal('Untranslated %{ n } items')
+
+    // Test plural message with multiple contexts (default context and 'Context'')
+    translated = translate.getTranslation('%{ carCount } car (multiple contexts)', 1, null, null, 'en_US')
+    expect(translated).to.equal('1 car')
+    translated = translate.getTranslation('%{ carCount } car (multiple contexts)', 2, null, null, 'en_US')
+    expect(translated).to.equal('%{ carCount } cars')
+    translated = translate.getTranslation('%{ carCount } car (multiple contexts)', 1, 'Context', null, 'en_US')
+    expect(translated).to.equal('1 car with context')
+    translated = translate.getTranslation('%{ carCount } car (multiple contexts)', 2, 'Context', null, 'en_US')
+    expect(translated).to.equal('%{ carCount } cars with context')
+
+  })
+
+  it('tests the gettext() method', () => {
+
+    let undetectableGettext = translate.gettext.bind(translate)  // Hide from gettext-extract.
+
+    config.language = 'fr_FR'
+    expect(undetectableGettext('Pending')).to.equal('En cours')
+
+    config.language = 'en_US'
+    expect(undetectableGettext('Pending')).to.equal('Pending')
+
+  })
+
+  it('tests the pgettext() method', () => {
+
+    let undetectablePgettext = translate.pgettext.bind(translate)  // Hide from gettext-extract.
+
+    config.language = 'fr_FR'
+    expect(undetectablePgettext('Noun', 'Answer')).to.equal('Réponse (nom)')
+
+    config.language = 'en_US'
+    expect(undetectablePgettext('Noun', 'Answer')).to.equal('Answer (noun)')
+
+  })
+
+  it('tests the ngettext() method', () => {
+
+    let undetectableNgettext = translate.ngettext.bind(translate)  // Hide from gettext-extract.
+
+    config.language = 'fr_FR'
+    expect(undetectableNgettext('%{ carCount } car', '%{ carCount } cars', 2)).to.equal('%{ carCount } véhicules')
+
+    config.language = 'en_US'
+    expect(undetectableNgettext('%{ carCount } car', '%{ carCount } cars', 2)).to.equal('%{ carCount } cars')
+
+    // If no translation exists, display the default singular form (if n < 2).
+    config.language = 'fr_FR'
+    expect(undetectableNgettext('Untranslated %{ n } item', 'Untranslated %{ n } items', -1))
+      .to.equal('Untranslated %{ n } item')
+
+    // If no translation exists, display the default plural form (if n > 1).
+    config.language = 'fr_FR'
+    expect(undetectableNgettext('Untranslated %{ n } item', 'Untranslated %{ n } items', 2))
+      .to.equal('Untranslated %{ n } items')
+
+  })
+
+  it('tests the npgettext() method', () => {
+
+    let undetectableNpgettext = translate.npgettext.bind(translate)  // Hide from gettext-extract
+
+    config.language = 'fr_FR'
+    expect(undetectableNpgettext('Noun', '%{ carCount } car (noun)', '%{ carCount } cars (noun)', 2))
+      .to.equal('%{ carCount } véhicules (nom)')
+
+    config.language = 'en_US'
+    expect(undetectableNpgettext('Verb', '%{ carCount } car (verb)', '%{ carCount } cars (verb)', 2))
+      .to.equal('%{ carCount } cars (verb)')
+
+    config.language = 'fr_FR'
+    expect(undetectableNpgettext('Noun', '%{ carCount } car (noun)', '%{ carCount } cars (noun)', 1))
+      .to.equal('%{ carCount } véhicule (nom)')
+
+    config.language = 'en_US'
+    expect(undetectableNpgettext('Verb', '%{ carCount } car (verb)', '%{ carCount } cars (verb)', 1))
+      .to.equal('%{ carCount } car (verb)')
+
+    // If no translation exists, display the default singular form (if n < 2).
+    config.language = 'fr_FR'
+    expect(undetectableNpgettext('Noun', 'Untranslated %{ n } item (noun)', 'Untranslated %{ n } items (noun)', 1))
+      .to.equal('Untranslated %{ n } item (noun)')
+
+    // If no translation exists, display the default plural form (if n > 1).
+    config.language = 'fr_FR'
+    expect(undetectableNpgettext('Noun', 'Untranslated %{ n } item (noun)', 'Untranslated %{ n } items (noun)', 2))
+      .to.equal('Untranslated %{ n } items (noun)')
+
+  })
+
+  it('works when a msgid exists with and without a context, but the one with the context has not been translated', () => {
+
+    expect(config.silent).to.equal(false)
+    console.warn = sinon.spy(console, 'warn')
+
+    translated = translate.getTranslation('May', null, null, null, 'fr_FR')
+    expect(translated).to.equal('Pourrait')
+
+    translated = translate.getTranslation('May', null, 'Month name', null, 'fr_FR')
+    expect(translated).to.equal('May')
+
+    expect(console.warn).calledOnce
+    expect(console.warn).calledWith('Untranslated fr_FR key found: May (with context: Month name)')
+
+    console.warn.restore()
+
+  })
+
+})


### PR DESCRIPTION
This makes it possible to use vue-gettext without Vue.
Use case is to reuse vue-gettext for nodejs scripts
that need only the gettext API for translations.