### PR TITLE
translate: add 'language' parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ import {translate} from 'vue-gettext';
 const {gettext: $gettext, gettextInterpolate} = translate;
 
 const str = $gettext('Hello, %{name}');
+const strFR = $gettext('Hello, %{name}', 'fr');
 const interpolated = gettextInterpolate(str, { name: 'Jerom' })
 ```
 

--- a/src/translate.js
+++ b/src/translate.js
@@ -115,11 +115,12 @@ const translate = {
    * Also makes the string discoverable by gettext-extract.
    *
    * @param {String} msgid - The translation key
+   * @param {String} language - The language ID (e.g. 'fr_FR' or 'en_US')
    *
    * @return {String} The translated string
   */
-  'gettext': function (msgid) {
-    return translate.getTranslation(msgid)
+  'gettext': function (msgid, language = _config.language) {
+    return translate.getTranslation(msgid, 1, null, null, language)
   },
 
   /*
@@ -128,11 +129,12 @@ const translate = {
    *
    * @param {String} context - The context of the string to translate
    * @param {String} msgid - The translation key
+   * @param {String} language - The language ID (e.g. 'fr_FR' or 'en_US')
    *
    * @return {String} The translated string
   */
-  'pgettext': function (context, msgid) {
-    return translate.getTranslation(msgid, 1, context)
+  'pgettext': function (context, msgid, language = _config.language) {
+    return translate.getTranslation(msgid, 1, context, null, language)
   },
 
   /*
@@ -143,11 +145,12 @@ const translate = {
    * @param {String} msgid - The translation key
    * @param {String} plural - The plural form of the translation key
    * @param {Number} n - The number to switch between singular and plural
+   * @param {String} language - The language ID (e.g. 'fr_FR' or 'en_US')
    *
    * @return {String} The translated string
   */
-  'ngettext': function (msgid, plural, n) {
-    return translate.getTranslation(msgid, n, null, plural)
+  'ngettext': function (msgid, plural, n, language = _config.language) {
+    return translate.getTranslation(msgid, n, null, plural, language)
   },
 
   /*
@@ -159,11 +162,12 @@ const translate = {
    * @param {String} msgid - The translation key
    * @param {String} plural - The plural form of the translation key
    * @param {Number} n - The number to switch between singular and plural
+   * @param {String} language - The language ID (e.g. 'fr_FR' or 'en_US')
    *
    * @return {String} The translated string
   */
-  'npgettext': function (context, msgid, plural, n) {
-    return translate.getTranslation(msgid, n, context, plural)
+  'npgettext': function (context, msgid, plural, n, language = _config.language) {
+    return translate.getTranslation(msgid, n, context, plural, language)
   },
 
   /*

--- a/test/specs/translate.spec.js
+++ b/test/specs/translate.spec.js
@@ -92,6 +92,7 @@ describe('Translate tests', () => {
     Vue.config.language = 'en_US'
     expect(undetectableGettext('Pending')).to.equal('Pending')
 
+    expect(undetectableGettext('Pending', 'fr_FR')).to.equal('En cours')
   })
 
   it('tests the pgettext() method', () => {
@@ -104,6 +105,7 @@ describe('Translate tests', () => {
     Vue.config.language = 'en_US'
     expect(undetectablePgettext('Noun', 'Answer')).to.equal('Answer (noun)')
 
+    expect(undetectablePgettext('Noun', 'Answer', 'fr_FR')).to.equal('Réponse (nom)')
   })
 
   it('tests the ngettext() method', () => {
@@ -115,6 +117,8 @@ describe('Translate tests', () => {
 
     Vue.config.language = 'en_US'
     expect(undetectableNgettext('%{ carCount } car', '%{ carCount } cars', 2)).to.equal('%{ carCount } cars')
+
+    expect(undetectableNgettext('%{ carCount } car', '%{ carCount } cars', 2, 'fr_FR')).to.equal('%{ carCount } véhicules')
 
     // If no translation exists, display the default singular form (if n < 2).
     Vue.config.language = 'fr_FR'
@@ -147,6 +151,9 @@ describe('Translate tests', () => {
     Vue.config.language = 'en_US'
     expect(undetectableNpgettext('Verb', '%{ carCount } car (verb)', '%{ carCount } cars (verb)', 1))
       .to.equal('%{ carCount } car (verb)')
+
+    expect(undetectableNpgettext('Noun', '%{ carCount } car (noun)', '%{ carCount } cars (noun)', 2, 'fr_FR'))
+      .to.equal('%{ carCount } véhicules (nom)')
 
     // If no translation exists, display the default singular form (if n < 2).
     Vue.config.language = 'fr_FR'
@@ -265,6 +272,7 @@ describe('Translate tests without Vue', () => {
     config.language = 'en_US'
     expect(undetectableGettext('Pending')).to.equal('Pending')
 
+    expect(undetectableGettext('Pending', 'fr_FR')).to.equal('En cours')
   })
 
   it('tests the pgettext() method', () => {
@@ -277,6 +285,7 @@ describe('Translate tests without Vue', () => {
     config.language = 'en_US'
     expect(undetectablePgettext('Noun', 'Answer')).to.equal('Answer (noun)')
 
+    expect(undetectablePgettext('Noun', 'Answer', 'fr_FR')).to.equal('Réponse (nom)')
   })
 
   it('tests the ngettext() method', () => {
@@ -288,6 +297,8 @@ describe('Translate tests without Vue', () => {
 
     config.language = 'en_US'
     expect(undetectableNgettext('%{ carCount } car', '%{ carCount } cars', 2)).to.equal('%{ carCount } cars')
+
+    expect(undetectableNgettext('%{ carCount } car', '%{ carCount } cars', 2, 'fr_FR')).to.equal('%{ carCount } véhicules')
 
     // If no translation exists, display the default singular form (if n < 2).
     config.language = 'fr_FR'
@@ -320,6 +331,9 @@ describe('Translate tests without Vue', () => {
     config.language = 'en_US'
     expect(undetectableNpgettext('Verb', '%{ carCount } car (verb)', '%{ carCount } cars (verb)', 1))
       .to.equal('%{ carCount } car (verb)')
+
+    expect(undetectableNpgettext('Noun', '%{ carCount } car (noun)', '%{ carCount } cars (noun)', 1, 'fr_FR'))
+      .to.equal('%{ carCount } véhicule (nom)')
 
     // If no translation exists, display the default singular form (if n < 2).
     config.language = 'fr_FR'


### PR DESCRIPTION
It is convenient to fetch a translation for a specific language
without running 'translate.initTranslations()'
to change  the default language.
'language' property in the config could be set
outside of translate.js
but code that imports only 'vue-gettext' may not have access to the config.

Use-case:
vue-gettext is used for all translations in a nodejs server
that accepts language as a request parameter (or query).
It should be able to pass the language to '$gettext()'
if it is not the default language.