### PR TITLE
Fix double escape in component.

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -78,7 +78,7 @@ export default {
         context = Object.assign({}, this.$parent, this.translateParams)
       }
 
-      return this.$gettextInterpolate(translation, context)
+      return this.$gettextInterpolate(translation, context, true)
     },
   },
 

--- a/test/specs/component.spec.js
+++ b/test/specs/component.spec.js
@@ -128,6 +128,17 @@ describe('translate component tests', () => {
     expect(vm.$el.innerHTML.trim()).to.equal('<span>Bonjour John Doe</span><span>Bonjour Chester</span>')
   })
 
+  it('does not double escape in interpolation', () => {
+    Vue.config.language = 'fr_FR'
+    let vm = new Vue({
+      template: '<p><translate>%{ text }</translate></p>',
+      data: {
+        text: '<script>"</script>',
+      },
+    }).$mount()
+    expect(vm.$el.innerHTML.trim()).to.equal('<span>&lt;script&gt;"&lt;/script&gt;</span>')
+  })
+
   it('translates plurals', () => {
     Vue.config.language = 'fr_FR'
     let vm = new Vue({


### PR DESCRIPTION
Passing the interpolated string to createElement will escape html code again resulting in html code being shown to the user.